### PR TITLE
Improve code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,21 +11,19 @@ fn main() {
         .author(crate_authors!())
         .arg(Arg::with_name("from")
             .help("The file you want to copy")
-            .index(1))
+            .index(1)
+            .required(true))
         .arg(Arg::with_name("to")
             .help("The destination")
-            .index(2))
+            .index(2)
+            .required(true))
         .get_matches();
 
-    if matches.is_present("from") && matches.is_present("to") {
-        copy_to(matches.value_of("from").unwrap(), matches.value_of("to").unwrap());
-    } else {
-        println!("Wrong!");
-    }
+    copy_to(matches.value_of("from").unwrap(), matches.value_of("to").unwrap());
 }
 
 fn copy_to(from: &str, to: &str) {
-    match fs::copy(from, to) {
-        Err => Err("Operation failed")
-    };
+    if let Err(err) = fs::copy(from, to) {
+        eprintln!("operation failed: {}", err);
+    }
 }


### PR DESCRIPTION
Awesome work on RCP!
The code in `copy_to` didn't compile. This is because of three reasons:

 - You need to get the inner value. In this case you ignored it, so you can use `Err(_)`. All variables starting with _ don't complain about being unused.
 - You need to catch all possible values, so add `Ok(_) => {}`.
 - `Err("Operation failed")` does not in fact print that out. Use `eprintln!` for that.

------------------------

Ok, compile errors out of the way, here are a few nitpicks:

 - Since you only care about one possible enum variant, you can use `if let` on the result of `fs::copy`!
 - Printing the error out is probably a good idea.
 - `println!("Wrong!")` prints it out to STDOUT. Standard output. To print errors, you should print it to STDERR, standard error. Use `eprintln!("Wrong!")` for that.
 - Actually, no need to check if they're present at all. `clap-rs` has a `required` function for this very reason.